### PR TITLE
feat(cli): ask template interactively (single-project vs multi-repo)

### DIFF
--- a/packages/create-nonoise/package.json
+++ b/packages/create-nonoise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nonoise",
-  "version": "0.23.74",
+  "version": "0.23.75",
   "description": "SDLC bootstrapper — scaffolds projects with skills, agents, and tools",
   "type": "module",
   "repository": {

--- a/packages/create-nonoise/package.json
+++ b/packages/create-nonoise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nonoise",
-  "version": "0.23.75",
+  "version": "0.23.76",
   "description": "SDLC bootstrapper — scaffolds projects with skills, agents, and tools",
   "type": "module",
   "repository": {

--- a/packages/create-nonoise/src/index.ts
+++ b/packages/create-nonoise/src/index.ts
@@ -51,7 +51,13 @@ function parseArgv(args: string[]): ParsedFlags {
     else if (a === '--version' || a === '-v') out.version = true;
     else if (a === '--yes' || a === '-y') out.yes = true;
     else if (a === '--no-git') out.noGit = true;
-    else if (a === '--template') out.template = args[++i] as TemplateName;
+    else if (a === '--template') {
+      const raw = args[++i];
+      if (raw !== 'single-project' && raw !== 'multi-repo') {
+        throw new Error(`Unknown template "${raw}". Valid: single-project | multi-repo.`);
+      }
+      out.template = raw as TemplateName;
+    }
     else if (a === '--ai') out.ai = args[++i];
     else if (!a.startsWith('-') && !out.positionalDir) out.positionalDir = a;
     i++;
@@ -73,7 +79,7 @@ Usage:
   create-nonoise [directory] [options]
 
 Options:
-  --template <name>   Template name (default: single-project)
+  --template <name>   Template: single-project | multi-repo (default: single-project; asked interactively if omitted)
   --ai <csv>          AI tools: claude-code,copilot,codex,cursor,gemini-cli
   --no-git            Skip git init
   --yes, -y           Use defaults, non-interactive

--- a/packages/create-nonoise/src/prompts.ts
+++ b/packages/create-nonoise/src/prompts.ts
@@ -1,4 +1,4 @@
-import { intro, outro, text, multiselect, confirm, isCancel, cancel, spinner, note } from '@clack/prompts';
+import { intro, outro, text, select, multiselect, confirm, isCancel, cancel, spinner, note } from '@clack/prompts';
 import { resolve } from 'node:path';
 import type { AiToolKey, AiTools, ProjectContext, TemplateName } from './types.js';
 
@@ -22,7 +22,7 @@ export async function runPrompts(flags: CliFlags, frameworkVersion: string): Pro
   intro('create-nonoise • SDLC bootstrapper');
 
   const name = await askProjectName(flags);
-  const template = flags.template ?? 'single-project';
+  const template = await askTemplate(flags);
   const aiTools = await askAiTools(flags);
   const gitInit = flags.noGit === true ? false : flags.yes === true ? true : await askGitInit();
 
@@ -62,6 +62,30 @@ function validateProjectName(name: string): void {
     throw new Error('Use kebab-case: lowercase letters, digits, and single hyphens.');
   }
   if (name.length > 214) throw new Error('Project name is too long (max 214 chars).');
+}
+
+async function askTemplate(flags: CliFlags): Promise<TemplateName> {
+  if (flags.template) return flags.template;
+  if (flags.yes) return 'single-project';
+
+  const answer = await select({
+    message: 'What are you setting up?',
+    options: [
+      {
+        value: 'single-project' as TemplateName,
+        label: 'New project (single repo)',
+        hint: 'Scaffold a fresh project from scratch',
+      },
+      {
+        value: 'multi-repo' as TemplateName,
+        label: 'Existing multi-repo workspace',
+        hint: 'Wrap one or more existing repos with NONoise',
+      },
+    ],
+    initialValue: 'single-project' as TemplateName,
+  });
+  abortIfCancel(answer);
+  return answer as TemplateName;
 }
 
 async function askAiTools(flags: CliFlags): Promise<AiTools> {

--- a/packages/create-nonoise/src/types.ts
+++ b/packages/create-nonoise/src/types.ts
@@ -7,7 +7,7 @@ export type AiToolKey =
 
 export type AiTools = Record<AiToolKey, boolean>;
 
-export type TemplateName = 'single-project';
+export type TemplateName = 'single-project' | 'multi-repo';
 
 export type ProjectContext = {
   projectName: string;


### PR DESCRIPTION
Previously the interactive installer silently defaulted to the
single-project template; the multi-repo template was only reachable via
the --template flag, so users wrapping an existing multi-repo workspace
had no discoverable path. Now runPrompts asks which kind of project is
being set up, bumps the version to 0.23.75, validates the --template
flag value, and widens TemplateName to include 'multi-repo'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "multi-repo" template option for project creation.
  * Improved template selection with interactive prompting when not specified via command-line.

* **Bug Fixes**
  * Added validation for `--template` argument to reject invalid values and display valid options.

* **Documentation**
  * Updated help text to reflect available template options and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->